### PR TITLE
FixCommandLogging

### DIFF
--- a/src/main/java/frc/cotc/CommandsLogging.java
+++ b/src/main/java/frc/cotc/CommandsLogging.java
@@ -23,7 +23,7 @@ import org.littletonrobotics.junction.Logger;
 public class CommandsLogging {
   private static final Set<Command> runningNonInterrupters = new HashSet<>();
   private static final Set<Command> runningInterrupters = new HashSet<>();
-  private static final Map<Command, Command> interrupted = new HashMap<>();
+  private static final Map<Command, Command> interruptedCommands = new HashMap<>();
   private static final Map<Subsystem, Command> requiredSubsystems = new HashMap<>();
 
   public static void commandStarted(final Command command) {
@@ -312,7 +312,7 @@ public class CommandsLogging {
 
     final var interrupters = new ArrayList<String>();
     for (final var interrupter : runningInterrupters) {
-      for (final var interruptEntry : interrupted.entrySet()) {
+      for (final var interruptEntry : interruptedCommands.entrySet()) {
         if (interruptEntry.getValue() != interrupter) {
           continue;
         }
@@ -343,6 +343,14 @@ public class CommandsLogging {
     }
 
     Logger.recordOutput("CommandScheduler/Running/errors", interrupters.toArray(new String[0]));
+  }
+
+  public static void logInterrupts(Command interrupted, Optional<Command> interrupting) {
+    interrupting.ifPresent(
+        interrupter -> {
+          runningInterrupters.add(interrupter);
+          interruptedCommands.put(interrupted, interrupter);
+        });
   }
 
   private static void addCommand(

--- a/src/main/java/frc/cotc/Robot.java
+++ b/src/main/java/frc/cotc/Robot.java
@@ -103,13 +103,7 @@ public class Robot extends LoggedRobot {
 
     CommandScheduler.getInstance().onCommandInitialize(CommandsLogging::commandStarted);
     CommandScheduler.getInstance().onCommandFinish(CommandsLogging::commandEnded);
-    CommandScheduler.getInstance()
-        .onCommandInterrupt(
-            (interrupted, interrupting) -> {
-              interrupting.ifPresent(
-                  interrupter -> CommandsLogging.runningInterrupters.put(interrupter, interrupted));
-              CommandsLogging.commandEnded(interrupted);
-            });
+    CommandScheduler.getInstance().onCommandInterrupt(CommandsLogging::logInterrupts);
 
     var swerve =
         new Swerve(


### PR DESCRIPTION
> @Hydra | FRC 167 | FTC 8696 FYI I found a bug in the commands logging impl I made
> 
> when a command runs, it can interrupt more than 1 command, and the original impl (which I haven't really touched) puts the interrupter command into a map as the key, which means if it interrupted more than 1, only the "last" one interrupted is actually logged
> 
> I pushed a fix [here](https://github.com/HarryXChen3/studious-spoon/commit/82f9670af6506e41d1032be1d14eee1387723fcf) in case you are interested

\- Harry | 1683 alum, FRC Discord